### PR TITLE
test.nix: expose weirdDrv.{ca,ia}

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,9 @@
+{
+  nixpkgs ? <nixpkgs>,
+  pkgs ? import nixpkgs { },
+}:
+
+pkgs.lib.makeScope pkgs.python3Packages.newScope (self: {
+  laut = self.callPackage ./package.nix { };
+  laut-sign-only = self.laut.override { sign-only = true; };
+})

--- a/flake.nix
+++ b/flake.nix
@@ -32,98 +32,23 @@
           nix derivation show --recursive ${nixpkgs-ca}#hello
         '';
 
-        nix-verify-souffle = pkgs.python3.pkgs.buildPythonApplication {
-          pname = "nix_verify_souffle";
-          version = "0.1.0";
-
-          src = ./datalog;
-
-          format = "other";
-          build-system = [
-            pkgs.python3.pkgs.hatchling
-          ];
-          nativeBuildInputs = with pkgs; [
-            souffle
-          ];
-
-          pythonImportsCheck = [ "nix_verify_souffle" ];
-          doCheck = true;
-
-          buildPhase = ''
-            souffle -o nix_verify_souffle $src/nix_verify.dl
-            souffle -s python $src/nix_verify.dl
-          '';
-
-          installPhase = ''
-            PKGS_PATH=$out/${pkgs.python3.sitePackages}/nix_verify_souffle
-            mkdir -p $out/bin $PKGS_PATH
-            cp nix_verify_souffle $out/bin/
-            touch $PKGS_PATH/__init__.py
-            cp SwigInterface.py $PKGS_PATH/SwigInterface.py
-            cp _SwigInterface.so $PKGS_PATH/_SwigInterface.so
-          '';
-        };
-
-        laut-f = sign-only: pkgs.python3.pkgs.buildPythonApplication {
-          pname = "laut";
-          version = "0.1.0";
-          format = "pyproject";
-
-          src = lib.sourceByRegex ./. [
-            "^src(/laut(/.*)?)?$"
-            "^tests(/.*)?$"
-            "^testkeys(/.*)?$"
-            "^pyproject\.toml$"
-            "^LICENSE\.md$"
-            "^README\.md$"
-          ];
-
-          nativeBuildInputs = with pkgs.python3.pkgs; [
-            setuptools
-            setuptools-scm
-          ] ++ (if sign-only then [] else [
-            pytestCheckHook
-          ]);
-
-          postPatch =  if sign-only then ''
-            substituteInPlace "src/laut/build_config.py" \
-              --replace-fail "sign_only = False" "sign_only = True"
-          '' else "";
-
-          nativeCheckInputs = with pkgs.python3.pkgs; [
-            pytest
-          ];
-
-          propagatedBuildInputs = with pkgs.python3.pkgs; [
-            rfc8785
-            pyjwt
-            cryptography
-            boto3
-            click
-            sigstore
-            loguru
-          ] ++ (if sign-only then [] else [
-            nix-verify-souffle
-          ]);
-
-          pythonImportsCheck = [ "laut" ];
-        };
-
-        laut = laut-f false;
-        laut-sign-only = laut-f true;
-
+        scope = pkgs.callPackage ./default.nix { nixpkgs = null; };
     in {
         packages = {
-          inherit nix nix-vsbom laut laut-sign-only nix-verify-souffle test-drv-json;
-          default = laut;
-        };
+          inherit nix nix-vsbom test-drv-json;
+          default = scope.laut;
+        } // scope;
+
 
         checks = lib.filterAttrs (name: value:
           # since trust models are not implemented yet
           # it makes no sense to run more than one VM test
           (name == "fullReproVM"))
           (import ./test.nix {
-            inherit pkgs nix-vsbom inputs laut nixpkgs-ca;
+            pkgsCA = nixpkgs-ca;
+            pkgsIA = pkgs;
+            inherit nixpkgs;
+            inherit (scope) laut;
           });
 
         devShell = let

--- a/nix/laut.nix
+++ b/nix/laut.nix
@@ -1,0 +1,82 @@
+{
+  lib,
+  buildPythonApplication,
+  setuptools,
+  setuptools-scm,
+  pytestCheckHook,
+  rfc8785,
+  pyjwt,
+  cryptography,
+  boto3,
+  click,
+  sigstore,
+  loguru,
+  sign-only ? false,
+  nix-verify-souffle,
+}:
+
+buildPythonApplication {
+  pname = "laut";
+  version = "0.1.0";
+  pyproject = true;
+
+  src =
+    let
+      fs = lib.fileset;
+    in
+    fs.toSource {
+      root = ../.;
+      fileset = fs.unions [
+        ../src/laut
+        ../tests
+        ../testkeys
+        ../pyproject.toml
+        ../LICENSE.md
+        ../README.md
+      ];
+    };
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  postPatch =
+    if sign-only then
+      ''
+        substituteInPlace "src/laut/build_config.py" \
+          --replace-fail "sign_only = False" "sign_only = True"
+      ''
+    else
+      "";
+
+  nativeCheckInputs = (
+    if sign-only then
+      [ ]
+    else
+      [
+        pytestCheckHook
+      ]
+  );
+
+  dependencies =
+    [
+      rfc8785
+      pyjwt
+      cryptography
+      boto3
+      click
+      sigstore
+      loguru
+    ]
+    ++ (
+      if sign-only then
+        [ ]
+      else
+        [
+          nix-verify-souffle
+        ]
+    );
+
+  pythonImportsCheck = [ "laut" ];
+}

--- a/nix/nix-verify-souffle.nix
+++ b/nix/nix-verify-souffle.nix
@@ -1,0 +1,42 @@
+{
+  buildPythonApplication,
+  python,
+  hatchling,
+  souffle,
+}:
+
+buildPythonApplication {
+  pname = "nix_verify_souffle";
+  version = "0.1.0";
+
+  src = ../datalog;
+
+  format = "other";
+  build-system = [
+    hatchling
+  ];
+  nativeBuildInputs = [
+    souffle
+  ];
+
+  pythonImportsCheck = [ "nix_verify_souffle" ];
+  doCheck = true;
+
+  buildPhase = ''
+    runHook preBuild
+    souffle -o nix_verify_souffle $src/nix_verify.dl
+    souffle -s python $src/nix_verify.dl
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    PKGS_PATH=$out/${python.sitePackages}/nix_verify_souffle
+    mkdir -p $out/bin $PKGS_PATH
+    cp nix_verify_souffle $out/bin/
+    touch $PKGS_PATH/__init__.py
+    cp SwigInterface.py $PKGS_PATH/SwigInterface.py
+    cp _SwigInterface.so $PKGS_PATH/_SwigInterface.so
+    runHook postInstall
+  '';
+}

--- a/test.nix
+++ b/test.nix
@@ -366,4 +366,10 @@ in
   weirdDrv.ca' = lib.getAttrFromPath trivialPackageCa pkgsCA';
   weirdDrv.ca = lib.getAttrFromPath trivialPackageCa pkgsCA;
   weirdDrv.ia = lib.getAttrFromPath trivialPackageCa pkgsIA;
+
+  weirdDrv.mk-diff = pkgsIA.writeShellScriptBin "mk-diff" ''
+    ${lib.getExe' pkgsIA.nix "nix-instantiate"} -A weirdDrv."ca" test.nix | xargs ${lib.getExe pkgsIA.nix} derivation show | ${lib.getExe pkgsIA.jq} > ca.json
+    ${lib.getExe' pkgsIA.nix "nix-instantiate"} -A weirdDrv."ia" test.nix | xargs ${lib.getExe pkgsIA.nix} derivation show | ${lib.getExe pkgsIA.jq} > ia.json
+    ${lib.getExe pkgsIA.delta} ia.json ca.json
+  '';
 }


### PR DESCRIPTION
- Make it possible to  `nix-instantiate -A weirdDrv.ca test.nix`
    - In particular, use `test.nix` w/o flakes and flake inputs
    - Expose `laut` and `nix-verify-souffle` in `default.nix` as a "scope"
    - Reuse the scope in `flake.nix
    - Update the nixos config to use the pinned nixpkgs w/o flake registry (as channels in `nixPath`). This is untested!
    - Use attrByPath for `trivialPackageCa` (now `weirdDrv.ca`) `test.nix`