### PR TITLE
[codex] Add self-reference flags to trace signatures

### DIFF
--- a/laut-sign/src/nix_cmd.rs
+++ b/laut-sign/src/nix_cmd.rs
@@ -91,3 +91,62 @@ pub fn output_hash_from_disk(out_path: &str) -> Result<String, Error> {
     )?;
     Ok(raw.trim().to_owned())
 }
+
+/// `nix-store --query --references <path>` — returns immediate references.
+pub fn output_references(out_path: &str) -> Result<Vec<String>, Error> {
+    let raw = run_utf8(
+        "nix-store",
+        &["--query", "--references", out_path],
+        "nix-store --query --references",
+    )?;
+    Ok(parse_references(&raw))
+}
+
+pub fn output_has_self_reference(out_path: &str) -> Result<bool, Error> {
+    Ok(references_contain_path(
+        &output_references(out_path)?,
+        out_path,
+    ))
+}
+
+fn parse_references(raw: &str) -> Vec<String> {
+    raw.lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .map(str::to_owned)
+        .collect()
+}
+
+fn references_contain_path(references: &[String], path: &str) -> bool {
+    references.iter().any(|reference| reference == path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_references_ignores_blank_lines() {
+        let refs = parse_references(
+            "\n/nix/store/abc-one\n  /nix/store/def-two  \n\n/nix/store/ghi-three\n",
+        );
+
+        assert_eq!(
+            refs,
+            vec![
+                "/nix/store/abc-one",
+                "/nix/store/def-two",
+                "/nix/store/ghi-three",
+            ]
+        );
+    }
+
+    #[test]
+    fn references_contain_path_matches_exact_store_path() {
+        let refs =
+            parse_references("/nix/store/abc-one\n/nix/store/abc-one-extra\n/nix/store/def-two\n");
+
+        assert!(references_contain_path(&refs, "/nix/store/abc-one"));
+        assert!(!references_contain_path(&refs, "/nix/store/abc"));
+    }
+}

--- a/laut-sign/src/sign.rs
+++ b/laut-sign/src/sign.rs
@@ -133,6 +133,7 @@ pub fn sign(cfg: &SignConfig) -> Result<Option<(String, String)>, Error> {
     };
 
     let mut castore_outputs = serde_json::Map::new();
+    let mut self_references = serde_json::Map::new();
     for (name, entry) in output_hashes_map.iter() {
         let path = entry
             .get("path")
@@ -142,6 +143,10 @@ pub fn sign(cfg: &SignConfig) -> Result<Option<(String, String)>, Error> {
             })?;
         let encoded = content_hash::create_castore_entry(Path::new(path))?;
         castore_outputs.insert(name.clone(), Value::String(encoded));
+        self_references.insert(
+            name.clone(),
+            Value::Bool(nix_cmd::output_has_self_reference(path)?),
+        );
     }
 
     let mut buf = [0u8; 4];
@@ -161,6 +166,7 @@ pub fn sign(cfg: &SignConfig) -> Result<Option<(String, String)>, Error> {
         debug_data.as_ref(),
         &Value::Object(output_hashes_map),
         &Value::Object(castore_outputs),
+        &Value::Object(self_references),
         rebuild_id,
         flavor.as_deref(),
         version.as_deref(),

--- a/laut-sign/src/sign/jws.rs
+++ b/laut-sign/src/sign/jws.rs
@@ -21,13 +21,14 @@ pub enum Error {
 /// Build the laut trace JWS for one resolved derivation and sign it.
 ///
 /// `castore_outputs` and `output_hashes` are passed as already-built JSON
-/// values so the caller (Python orchestrator, tests with mock castore output,
-/// or a future Rust orchestrator) can shape them without touching this code.
+/// values. `self_references` is keyed by the same output names and stores a
+/// boolean flag for each output path.
 pub fn create_trace_signature(
     input_hash: &str,
     debug_data: Option<&Value>,
     output_hashes: &Value,
     castore_outputs: &Value,
+    self_references: &Value,
     rebuild_id: u32,
     builder_nix_flavor: Option<&str>,
     builder_nix_version: Option<&str>,
@@ -80,8 +81,8 @@ pub fn create_trace_signature(
         "out": {
             "castore-entry": castore_outputs,
             "nix": output_hashes,
+            "self-references": self_references,
             // TODO: add info about
-            //   * self-references, and
             //   * whether the output contains any references at all
             //     — if not, rewriting is a no-op and therefore harmless,
             //     which is especially relevant for bit-level reasoning.
@@ -125,12 +126,14 @@ mod tests {
             "out": { "path": "/nix/store/x-foo", "hash": "sha256:0000" }
         });
         let castore_outputs = json!({ "out": "abc123base64url" });
+        let self_references = json!({ "out": false });
 
         let jws = create_trace_signature(
             "input-hash-here",
             None,
             &output_hashes,
             &castore_outputs,
+            &self_references,
             42,
             Some("lix"),
             Some("2.91.1"),
@@ -159,6 +162,7 @@ mod tests {
         assert_eq!(payload["builder"]["nix_version"], "2.91.1");
         assert_eq!(payload["out"]["castore-entry"], castore_outputs);
         assert_eq!(payload["out"]["nix"], output_hashes);
+        assert_eq!(payload["out"]["self-references"], self_references);
 
         // Signature verifies against the recomputed signing input.
         let header_b64 = jws.split('.').next().unwrap();
@@ -179,6 +183,7 @@ mod tests {
         let jws = create_trace_signature(
             "h",
             Some(&debug),
+            &json!({}),
             &json!({}),
             &json!({}),
             0,


### PR DESCRIPTION
## Summary
- add per-output `out["self-references"]` booleans to trace JWS payloads
- detect self-references with `nix-store --query --references <out-path>` using exact store path matching
- cover payload serialization and reference parsing with tests

Closes #19.

## Validation
- `cargo test -p laut-sign`
- `git diff --check`

Not run locally: Nix payload/VM checks, because `nix` is not installed in this macOS environment.